### PR TITLE
Update control to fix light components

### DIFF
--- a/dist/elements/haiku-light-control.js
+++ b/dist/elements/haiku-light-control.js
@@ -55,10 +55,10 @@ li {
     height: 20px;
     margin-top: -3px; }
 
-paper-toggle-button {
+mwc-switch {
   display: flex;
   flex: 1 0 0;
-  margin-top: -4px;
+  margin-top: 4px;
   margin-right: 12px; }
 </style>
       <li>
@@ -68,8 +68,8 @@ paper-toggle-button {
             ${entity.attributes.haiku_label || entity.attributes.friendly_name}
           </span>
         </span>
-        <paper-toggle-button checked="${entity.state === 'on'}"
-          on-change="${(e) => this.toggleChanged(e)}"></paper-toggle-button>
+        <mwc-switch checked="${entity.state === 'on'}"
+          on-change="${(e) => this.toggleChanged(e)}"></mwc-switch>
       </li>
     `;
   }

--- a/dist/elements/haiku-light-group.js
+++ b/dist/elements/haiku-light-group.js
@@ -61,8 +61,9 @@ ul, li {
   .group-container.expanded > ul {
     max-height: 40rem; }
 
-paper-toggle-button {
-  margin-right: 12px; }
+mwc-switch {
+  margin-right: 12px;
+  margin-top: 15px; }
 
 .menu-toggle.entity {
   visibility: hidden; }
@@ -78,8 +79,8 @@ paper-toggle-button {
               ${ entity.attributes.haiku_label || entity.attributes.friendly_name }
             </span>
           </a>
-          <paper-toggle-button checked="${ entity.state === 'on' }"
-            on-change="${(e) => this.toggleChanged(e)}"></paper-toggle-button>
+          <mwc-switch checked="${ entity.state === 'on' }"
+            on-change="${(e) => this.toggleChanged(e)}"></mwc-switch>
         </span>
         <ul>
           ${_.map(entity.attributes.entity_id, (entityId) => this.renderLightControl(entityId))}

--- a/dist/elements/haiku-light-menu.js
+++ b/dist/elements/haiku-light-menu.js
@@ -67,8 +67,9 @@ ul, li {
   .haiku-light-menu > li.haiku-light-menu-placeholder {
     display: flex; }
 
-paper-toggle-button {
-  margin-right: 12px; }
+mwc-switch {
+  margin-right: 12px;
+  margin-top: 15px; }
 </style>
       <ul class$="haiku-light-menu ${ this.collapsed ? 'collapsed' : 'expanded' }">
         <li class="haiku-light-menu-placeholder">
@@ -79,8 +80,8 @@ paper-toggle-button {
             <ha-icon icon$="mdi:${ this.state === 'on' ? 'lightbulb-on' : 'lightbulb' }"></ha-icon>
             Lighting
           </a>
-          <paper-toggle-button checked="${ this.state === 'on' }"
-            on-change="${(e) => this.toggleChanged(e)}"></paper-toggle-button>
+          <mwc-switch checked="${ this.state === 'on' }"
+            on-change="${(e) => this.toggleChanged(e)}"></mwc-switch>
         </li>
         ${ _.map(entities, (entity) => html`<haiku-light-group hass="${hass}" entity="${entity}"></haiku-light-group>`)}
       </ul>

--- a/dist/elements/haiku-thermostat-tile.js
+++ b/dist/elements/haiku-thermostat-tile.js
@@ -15,7 +15,6 @@ export class HaikuThermostatTile extends HaikuTileBase {
   }
 
   _render({ entity }) {
-    console.log(entity);
     return html`
       <style>.stat-container {
   background: rgba(33, 33, 33, 0.7);
@@ -179,38 +178,6 @@ export class HaikuThermostatTile extends HaikuTileBase {
     }
     return '';
   }
-
-  // getShortValue(entity) {
-  //   if (this._hasUnit(entity)) {
-  //     if (entity.attributes.unit_of_measurement.match(/°/)) {
-  //       return `${ Math.round(entity.state) }°`;
-  //     }
-  //   }
-
-  //   if (isNaN(entity.state)) {
-  //     return entity.state;
-  //   }
-
-  //   return Math.round(entity.state).toString();
-  // }
-
-  // getLongValue(entity) {
-  //   if (this._hasUnit(entity)) {
-  //     return entity.state + entity.attributes.unit_of_measurement;
-  //   }
-  //   return entity.state;
-  // }
-
-  // getUnit(entity) {
-  //   if (this._hasUnit(entity)) {
-  //     return entity.attributes.unit_of_measurement.replace(/°/, '');
-  //   }
-  //   return '';
-  // }
-
-  // _hasUnit(entity) {
-  //   return entity.attributes && entity.attributes.unit_of_measurement;
-  // }
 }
 
 customElements.define('haiku-thermostat-tile', HaikuThermostatTile);

--- a/dist/haiku.css
+++ b/dist/haiku.css
@@ -31,9 +31,7 @@ body.haiku-dark {
   /* opacity for light text on a dark background */
   /* derived colors, to keep existing themes mostly working */
   /* set our toggle style */
-  --paper-toggle-button-checked-ink-color: #bada55;
-  --paper-toggle-button-checked-button-color: #bada55;
-  --paper-toggle-button-checked-bar-color: #292e21;
+  --mdc-theme-secondary: #bada55;
   /* set our slider style */ }
 
 .haiku-config-button {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haiku-ui/haiku",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A collection of cards and other web components for the Home Assistant Lovelace UI.",
   "private": false,
   "repository": {

--- a/src/elements/haiku-light-control.js
+++ b/src/elements/haiku-light-control.js
@@ -29,8 +29,8 @@ export class HaikuLightControl extends LitElement {
             ${entity.attributes.haiku_label || entity.attributes.friendly_name}
           </span>
         </span>
-        <paper-toggle-button checked="${entity.state === 'on'}"
-          on-change="${(e) => this.toggleChanged(e)}"></paper-toggle-button>
+        <mwc-switch checked="${entity.state === 'on'}"
+          on-change="${(e) => this.toggleChanged(e)}"></mwc-switch>
       </li>
     `;
   }

--- a/src/elements/haiku-light-control.scss
+++ b/src/elements/haiku-light-control.scss
@@ -14,9 +14,9 @@ li {
   }
 }
 
-paper-toggle-button {
+mwc-switch {
   display: flex;
   flex: 1 0 0;
-  margin-top: -4px;
+  margin-top: 4px;
   margin-right: 12px;
 }

--- a/src/elements/haiku-light-group.js
+++ b/src/elements/haiku-light-group.js
@@ -33,8 +33,8 @@ export class HaikuLightGroup extends LitElement {
               ${ entity.attributes.haiku_label || entity.attributes.friendly_name }
             </span>
           </a>
-          <paper-toggle-button checked="${ entity.state === 'on' }"
-            on-change="${(e) => this.toggleChanged(e)}"></paper-toggle-button>
+          <mwc-switch checked="${ entity.state === 'on' }"
+            on-change="${(e) => this.toggleChanged(e)}"></mwc-switch>
         </span>
         <ul>
           ${_.map(entity.attributes.entity_id, (entityId) => this.renderLightControl(entityId))}

--- a/src/elements/haiku-light-group.scss
+++ b/src/elements/haiku-light-group.scss
@@ -24,8 +24,9 @@
   }
 }
 
-paper-toggle-button {
+mwc-switch {
   margin-right: 12px;
+  margin-top: 15px;
 }
 
 .menu-toggle.entity {

--- a/src/elements/haiku-light-menu.js
+++ b/src/elements/haiku-light-menu.js
@@ -34,8 +34,8 @@ export class HaikuLightMenu extends LitElement {
             <ha-icon icon$="mdi:${ this.state === 'on' ? 'lightbulb-on' : 'lightbulb' }"></ha-icon>
             Lighting
           </a>
-          <paper-toggle-button checked="${ this.state === 'on' }"
-            on-change="${(e) => this.toggleChanged(e)}"></paper-toggle-button>
+          <mwc-switch checked="${ this.state === 'on' }"
+            on-change="${(e) => this.toggleChanged(e)}"></mwc-switch>
         </li>
         ${ _.map(entities, (entity) => html`<haiku-light-group hass="${hass}" entity="${entity}"></haiku-light-group>`)}
       </ul>

--- a/src/elements/haiku-light-menu.scss
+++ b/src/elements/haiku-light-menu.scss
@@ -30,6 +30,7 @@
   }
 }
 
-paper-toggle-button {
+mwc-switch {
   margin-right: 12px;
+  margin-top: 15px;
 }

--- a/src/styles/global/themes/theme-dark.scss
+++ b/src/styles/global/themes/theme-dark.scss
@@ -53,8 +53,7 @@ body.haiku-dark {
     When a default paper-style color is used, it needs to be copied
     from paper-styles/color.html to here.
   */
-  // --paper-grey-50: #fafafa; /* default for: --paper-toggle-button-unchecked-button-color */
-  // --paper-grey-200: #eeeeee;  /* for ha-date-picker-style */
+    // --paper-grey-200: #eeeeee;  /* for ha-date-picker-style */
   // --paper-grey-500: #9e9e9e;  /* --label-badge-grey */
   /* for paper-spinner */
   // --google-red-500: #db4437;
@@ -83,11 +82,7 @@ body.haiku-dark {
   // --table-row-background-color: var(--primary-background-color);
   // --table-row-alternative-background-color: var(--secondary-background-color);
   /* set our toggle style */
-  --paper-toggle-button-checked-ink-color: #bada55;
-  --paper-toggle-button-checked-button-color: #bada55;
-  --paper-toggle-button-checked-bar-color: #292e21;
-  // --paper-toggle-button-unchecked-button-color: var(--toggle-button-unchecked-color, var(--paper-grey-50));
-  // --paper-toggle-button-unchecked-bar-color: var(--toggle-button-unchecked-color, #000000);
+  --mdc-theme-secondary: #bada55;
   /* set our slider style */
   // --paper-slider-knob-color: var(--slider-color);
   // --paper-slider-knob-start-color: var(--slider-color);


### PR DESCRIPTION
In 0.100.1, the front-end moved from paper-toggle-switch to mwc-switch components. Because we're not directly referencing the paper-toggle-switch component (and instead relying on whatever HA gives us) the controls were no longer rendered.

This updates to the new Material Web Component control and updates theme styles accordingly.